### PR TITLE
MainloopをrequestAnimationFrameに変更

### DIFF
--- a/src/main-loop.ts
+++ b/src/main-loop.ts
@@ -1,23 +1,20 @@
 "use strict";
 // メインループ - 60 FPS のゲームの場合約 17 ms
 // 実行環境によってゲーム速度が変化するので、それを整えるためのFPS
-var FPS = 30;
-var MSPF = 1000 / FPS;
+export var FPS = 60;
+var lastTimeStamp:number;
+var render:Function;
+// http://qiita.com/zukkun/items/43466ba12e94b90a9f8d
+function tick(timeStamp:number) {
+    // 前回の呼び出しからの経過時間
+    var deltaTime = (timeStamp - lastTimeStamp) / 1000;
+    // var currentFPS = 1000 / (timeStamp - lastTimeStamp);
+    lastTimeStamp = timeStamp;
+    render(deltaTime);
+    requestAnimationFrame(tick);
+}
 export default function mainLoop(enterFrame:Function) {
-    var startTime = Date.now();
-    //処理
-    enterFrame();
-    // 処理の経過時間
-    var deltaTime:number = Date.now() - startTime;
-    // 次のループまでのintervalを算出
-    var interval = MSPF - deltaTime;
-    if (interval > 0) {
-        // interval分を待つ
-        setTimeout(()=>{
-            mainLoop(enterFrame);
-        }, interval);
-    } else {
-        // 次の処理へ
-        mainLoop(enterFrame);
-    }
+    lastTimeStamp = performance.now();
+    render = enterFrame;
+    requestAnimationFrame(tick);
 }

--- a/src/shooting.ts
+++ b/src/shooting.ts
@@ -84,7 +84,6 @@ function initialize() {
         enemiesHP[i_2] = 2;
     }
     mainLoop(()=> {
-        console.log(playerBulletsHP);
         // プレイヤーの移動
         movePlayer();
         // プレイヤーの弾

--- a/src/shooting.ts
+++ b/src/shooting.ts
@@ -1,5 +1,6 @@
 "use strict";
 import mainLoop from "./main-loop"
+import {FPS} from "./main-loop"
 var canvas:HTMLCanvasElement;
 var ctx:CanvasRenderingContext2D;
 interface IPosition {
@@ -83,13 +84,14 @@ function initialize() {
         };
         enemiesHP[i_2] = 2;
     }
-    mainLoop(()=> {
+
+    mainLoop((delta:number)=> {
         // プレイヤーの移動
-        movePlayer();
+        movePlayer(delta);
         // プレイヤーの弾
-        movePlayerBullets();
+        movePlayerBullets(delta);
         // 敵キャラの移動
-        moveEnemies();
+        moveEnemies(delta);
         // プレイヤーと敵で
         if (playerHP > 0 && playerStarInterval === 0) {
             for (var i = 0; i < ENEMIES_COUNT; i++) {
@@ -262,8 +264,8 @@ function onDraw() {
     }
 }
 // プレイヤーの弾
-function movePlayerBullets() {
-    var SPEED = -6;
+function movePlayerBullets(delta:number) {
+    var SPEED = -6 * FPS * delta;
     for (var i = 0; i < BULLETS; i++) {
         var playerBulletHP = playerBulletsHP[i];
         if (playerBulletHP <= 0) {
@@ -279,8 +281,8 @@ function movePlayerBullets() {
 
 }
 // 敵キャラの移動
-function moveEnemies() {
-    var SPEED = 2;
+function moveEnemies(delta:number) {
+    var SPEED = 2 * FPS * delta;
 
     function recover(enemy:IPosition):IPosition {
         if (enemy.y <= canvas.height) {
@@ -305,7 +307,7 @@ function moveEnemies() {
 }
 
 // プレイヤーの移動
-function movePlayer() {
+function movePlayer(delta:number) {
     if (playerHP <= 0) {
         return;
     }
@@ -316,7 +318,8 @@ function movePlayer() {
     var space = 32;
     var left = 37;
     var right = 39;
-    var SPEED = 2;
+    // 秒速120px
+    var SPEED = 2 * FPS * delta;
 
     if (keyStates[space] && playerFireInterval === 0) {
         for (var i = 0; i < BULLETS; i++) {


### PR DESCRIPTION
## PRの内容

ゲームのメインループをrequestAnimationFrameを使ったものへ変更します。
フレーム毎のオブジェクトの移動計算方法も変更しています。

前: 1回のループ(1フレーム)で2px
今: 1秒あたりの変化量は `2*FPS*delta`
(多分間違ってる)

というように変更しました
## 参考
- [JavaScriptでフルスクラッチゲーム開発しよう 第4回 更新編 - Qiita](http://qiita.com/zukkun/items/43466ba12e94b90a9f8d)
- [Home · uupaa/Clock.js Wiki](https://github.com/uupaa/Clock.js/wiki)
- [requestAnimationFrame and Date.now in WebKit - latest log](http://uupaa.hatenablog.com/entry/2015/03/03/223344)
## 疑問

これがまだ理解できてない。

[A Detailed Explanation of JavaScript Game Loops and Timing | Isaac Sukin](http://www.isaacsukin.com/news/2015/01/detailed-explanation-javascript-game-loops-and-timing)
